### PR TITLE
Enable allowNetworkAccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ $ kubectl config set-context --current --namespace ocean-compute
 $ kubectl apply -f kubernetes/sa.yml
 $ kubectl apply -f kubernetes/binding.yml
 $ kubectl apply -f kubernetes/operator.yml
+$ kubectl apply -f kubernetes/deny-algorithm-egress.yaml
 ```
 
 This will generate the `ocean-compute-operator` deployment in K8s. You can check the `Deployment` was created successfully 

--- a/kubernetes/deny-algorithm-egress.yaml
+++ b/kubernetes/deny-algorithm-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-algorithm-egress
+  namespace: ocean-compute
+spec:
+  podSelector:
+    matchExpressions:
+      - {key: component, operator: In, values: [algorithm]}
+      - {key: allowNetworkAccess, operator: DoesNotExist}
+    matchLabels:
+      component: algorithm
+  policyTypes:
+  - Egress
+  egress: []

--- a/operator_engine/resources.py
+++ b/operator_engine/resources.py
@@ -192,6 +192,13 @@ def create_algorithm_job(body, logger, resources):
     job['spec']['template']['metadata']['labels']['workflow'] = body['metadata']['labels']['workflow']
     job['spec']['template']['metadata']['labels']['component'] = 'algorithm'
 
+    # get algorithm asset
+    r = requests.get(f"{metadata['stages'][0]['output']['metadataUri']}/api/v1/aquarius/assets/ddo/{metadata['stages'][0]['algorithm']['id']}")
+    j = r.json()
+    network = j.get("service")[1].get("attributes").get('main').get('privacy').get('allowNetworkAccess')
+    if network == True:
+        job['spec']['template']['metadata']['labels']['allowNetworkAccess'] = 'true'
+
     #job['spec']['template']['spec']['containers'][0]['command'] = ['sh', '-c', OperatorConfig.POD_ALGORITHM_INIT_SCRIPT]
     command = OperatorConfig.POD_ALGORITHM_INIT_SCRIPT
     fullcommand = command.replace("CMDLINE", metadata['stages'][0]['algorithm']['container']['entrypoint'].replace(


### PR DESCRIPTION
Implement allowNetworkAccess, as outlined in the [documentation](https://docs.oceanprotocol.com/concepts/ddo-metadata/#fields-when-attributesmaintype--compute).

If the algorithm asset has `service.attributes.main.privacy.allowNetworkAccess` set to true,
the algorithm pod has full network access, otherwise all network access (including DNS) is blocked.

In `resources.py`, I am sure there is a better way to get the metadata json.