### PR TITLE
use docker digest if defined and starts with sha

### DIFF
--- a/operator_engine/resources.py
+++ b/operator_engine/resources.py
@@ -271,11 +271,13 @@ def create_algorithm_job(body, logger, resources):
         fullcommand,
     ]
     # job['spec']['template']['spec']['containers'][0]['command'] = metadata['stages'][0]['algorithm']['container']['entrypoint'].replace('$ALGO', OperatorConfig.TRANSFORMATIONS_FOLDER+"/algorithm")
-    if "checksum" in metadata['stages'][0]['algorithm']['container'] and metadata['stages'][0]['algorithm']['container']['checksum'].startswith('sha256:'):
+    if "checksum" in metadata["stages"][0]["algorithm"]["container"] and metadata[
+        "stages"
+    ][0]["algorithm"]["container"]["checksum"].startswith("sha256:"):
         job["spec"]["template"]["spec"]["containers"][0]["image"] = (
-        f"{metadata['stages'][0]['algorithm']['container']['image']}"
-        f":{metadata['stages'][0]['algorithm']['container']['checksum']}"
-    )
+            f"{metadata['stages'][0]['algorithm']['container']['image']}"
+            f":{metadata['stages'][0]['algorithm']['container']['checksum']}"
+        )
     else:
         job["spec"]["template"]["spec"]["containers"][0]["image"] = (
             f"{metadata['stages'][0]['algorithm']['container']['image']}"

--- a/operator_engine/resources.py
+++ b/operator_engine/resources.py
@@ -271,10 +271,16 @@ def create_algorithm_job(body, logger, resources):
         fullcommand,
     ]
     # job['spec']['template']['spec']['containers'][0]['command'] = metadata['stages'][0]['algorithm']['container']['entrypoint'].replace('$ALGO', OperatorConfig.TRANSFORMATIONS_FOLDER+"/algorithm")
-    job["spec"]["template"]["spec"]["containers"][0]["image"] = (
+    if "checksum" in metadata['stages'][0]['algorithm']['container'] and metadata['stages'][0]['algorithm']['container']['checksum'].startswith('sha256:'):
+        job["spec"]["template"]["spec"]["containers"][0]["image"] = (
         f"{metadata['stages'][0]['algorithm']['container']['image']}"
-        f":{metadata['stages'][0]['algorithm']['container']['tag']}"
+        f":{metadata['stages'][0]['algorithm']['container']['checksum']}"
     )
+    else:
+        job["spec"]["template"]["spec"]["containers"][0]["image"] = (
+            f"{metadata['stages'][0]['algorithm']['container']['image']}"
+            f":{metadata['stages'][0]['algorithm']['container']['tag']}"
+        )
 
     # Env
     dids = list()


### PR DESCRIPTION
Closes #69 

There is a fallback for now, if the docker checksum is not defined, we will use the tag.

This option is going to be removed soon