### PR TITLE
Cast ENV maxJobs to int to compute max_jobs_to_take

### DIFF
--- a/operator_engine/operator_main.py
+++ b/operator_engine/operator_main.py
@@ -225,7 +225,7 @@ def run_events_monitor():
             "storageExpiry": OperatorConfig.ENVIROMENT_storageExpiry,
             "maxJobDuration": OperatorConfig.ENVIROMENT_maxJobDuration,
         }
-        max_jobs_to_take = OperatorConfig.ENVIROMENT_maxJobs - current_jobs
+        max_jobs_to_take = int(OperatorConfig.ENVIROMENT_maxJobs) - current_jobs
         jobs = announce_and_get_sql_pending_jobs(logger, announce, max_jobs_to_take)
         for job in jobs:
             logger.info(f"Starting handler for job {job}")


### PR DESCRIPTION
Fixes #83

Changes proposed in this PR:

- Cast the ENV variable maxJobs from string to integer to compute max_jobs_to_take without error when the ENV var is set